### PR TITLE
Update to cpprestsdk 2.10.18.

### DIFF
--- a/recipes-cpprestsdk/cpprestsdk/cpprestsdk_2.10.18.bb
+++ b/recipes-cpprestsdk/cpprestsdk/cpprestsdk_2.10.18.bb
@@ -8,10 +8,10 @@ DESCRIPTION = "The C++ REST SDK is a Microsoft project for cloud-based \
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/license.txt;md5=a2e15b954769218ff912468eecd6a02f"
 
-SRCREV_cpprestsdk = "28919d0e127fc8d5cf57fae2db5d1b92b4eab381"
-SRC_URI = "git://github.com/Microsoft/cpprestsdk.git;branch=master;name=cpprestsdk"
+SRCREV_cpprestsdk = "122d09549201da5383321d870bed45ecb9e168c5"
+SRC_URI = "gitsm://github.com/Microsoft/cpprestsdk.git;branch=master;name=cpprestsdk"
 
-CPPRESTSDK_VERSION = "2.10.0"
+CPPRESTSDK_VERSION = "2.10.18"
 PV = "${CPPRESTSDK_VERSION}+git${SRCREV_cpprestsdk}"
 PR = "r0"
 
@@ -22,7 +22,7 @@ DEPENDS += " \
 S = "${WORKDIR}/git/Release"
 
 EXTRA_OECMAKE += "-DWERROR=OFF -DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF"
-inherit cmake pkgconfig 
+inherit cmake pkgconfig
 
 FILES_${PN} = "          \
     ${libdir}/lib*.so    \
@@ -32,9 +32,10 @@ FILES_${PN} = "          \
 FILES_${PN}-dev = "         \
     ${includedir}/*         \
     ${includedir}/cpprest/* \
-    ${includedir}/pplx/*    \    
+    ${includedir}/pplx/*    \
     ${libdir}/cpprestsdk    \
     ${libdir}/cpprestsdk/*  \
+    usr/lib/cmake/cpprestsdk/*  \
     "
 INSANE_SKIP_${PN} += "dev-so"
 INSANE_SKIP_${PN} += "dev-elf"


### PR DESCRIPTION
Earlier versions do not build with boost 1.70 which is packaged in
current Yocto.